### PR TITLE
Prevent test_cnn.py from crashing w/invalid Tensor label

### DIFF
--- a/python-api/test_cnn.py
+++ b/python-api/test_cnn.py
@@ -82,10 +82,15 @@ while True:
                     cv2.rectangle(frame, pt1, pt2, (0, 0, 255))
 
                     pt_t1 = x1, y1 + 20
-                    cv2.putText(frame, labels[int(e[0]['label'])], pt_t1, cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 0, 255), 2)
 
-                    pt_t2 = x1, y1 + 40
-                    cv2.putText(frame, str(e[0]['confidence']), pt_t2, cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 0, 255))
+                    # Handles case where TensorEntry object label = 7552.
+                    if e[0]['label'] > len(labels):
+                        print("Label index=",e[0]['label'], "is out of range. Not applying text to rectangle.")
+                    else:
+                        cv2.putText(frame, labels[int(e[0]['label'])], pt_t1, cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 0, 255), 2)
+
+                        pt_t2 = x1, y1 + 40
+                        cv2.putText(frame, str(e[0]['confidence']), pt_t2, cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 0, 255))
 
             cv2.imshow('previewout', frame)
 


### PR DESCRIPTION
When an object is detected and then leaves the image, the Tensor label returned is typically far outside the list of label indexes (ex: 7552.0). This causes the `test_cnn.py` to crash.

This checks to ensure the index is within the available labels before applying the label text.

The exception:

```
Traceback (most recent call last):
  File "test_cnn.py", line 85, in <module>
    cv2.putText(frame, labels[int(e[0]['label'])], pt_t1, cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 0, 255), 2)
IndexError: list index out of range
```