### PR TITLE
Pipeline Config options overwrite argument `-co` or `--config_overwrite``

### DIFF
--- a/python-api/calibrate.py
+++ b/python-api/calibrate.py
@@ -106,7 +106,7 @@ if 'capture' in args['mode']:
         print("[ERROR] Unable to initialize device. Try to reset it. Exiting.")
         exit(1)
 
-    config = configs = {
+    config = {
         'streams': ['left', 'right'],
         'depth':
         {

--- a/python-api/calibration_utils.py
+++ b/python-api/calibration_utils.py
@@ -6,6 +6,25 @@ import numpy as np
 import re
 import time
 
+# https://stackoverflow.com/questions/20656135/python-deep-merge-dictionary-data#20666342
+def merge(source, destination):
+    """
+    run me with nosetests --with-doctest file.py
+
+    >>> a = { 'first' : { 'all_rows' : { 'pass' : 'dog', 'number' : '1' } } }
+    >>> b = { 'first' : { 'all_rows' : { 'fail' : 'cat', 'number' : '5' } } }
+    >>> merge(b, a) == { 'first' : { 'all_rows' : { 'pass' : 'dog', 'fail' : 'cat', 'number' : '5' } } }
+    True
+    """
+    for key, value in source.items():
+        if isinstance(value, dict):
+            # get node or create one
+            node = destination.setdefault(key, {})
+            merge(value, node)
+        else:
+            destination[key] = value
+
+    return destination
 def mkdir_overwrite(dir):
     if not os.path.exists(dir):
         os.makedirs(dir)


### PR DESCRIPTION
This is a bit of an ugly "catchall": it allows you to overwrite the config `dict` passed to `depthai.create_pipeline()` in `calibrate.py` by passing thru a JSON-formatted string of config options. 

For example:

```
python calibrate.py -co '{"board_config": {"swap_left_and_right_cameras": true, "left_to_right_distance_cm": 9.0}}'
```

...will deep-merge those key/values on top of the default `config` dict.

This allows us to avoid defining a ton of arguments for potentially seldom-used options. 

/cc @Luxonis-Brian @Luxonis-Brandon 